### PR TITLE
#4 Add LookupRelatedField

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ django>=2.*,<=4.2
 pytest-django==4.5.2
 pytest-mock==3.8.2
 tox==3.25.1
-pydantic==1.10.7
+pydantic==2.0a4
 djangorestframework>=3.12

--- a/restdantic/models.py
+++ b/restdantic/models.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import field_validator
+from pydantic.fields import FieldInfo
+from pydantic.main import ModelMetaclass as PydanticModelMetaclass
+
+from restdantic.validators import validate_lookup_related_field
+
+
+class BaseModelMeta(PydanticModelMetaclass):
+    """
+    Extends the Pydantic ModelMetaclass to add additional attributes
+    to the class during creation.
+
+    This metaclass is used to implement additional validation for related lookup fields.
+    For each attribute in the class that has a FieldInfo instance
+    as its value and its `json_schema_extra` property has 'is_related_lookup' as True,
+    a new validation method is added to the class.
+
+    The new method is added before the class is created, allowing it to be used in the same
+    way as built-in validation methods.
+    """
+    def __new__(mcls, name, bases, attrs):
+        additional_attrs = {}
+        for attr_name, attr in attrs.items():
+            if isinstance(attr, FieldInfo):
+                json_schema_extra = attr.json_schema_extra or {}
+                if json_schema_extra.get('is_related_lookup'):
+                    additional_attrs[f'validate_{attr_name}'] = field_validator(
+                        attr_name, mode='before'
+                    )(validate_lookup_related_field)
+        attrs.update(additional_attrs)
+        return super().__new__(mcls, name, bases, attrs)
+
+
+class BaseModel(PydanticBaseModel, metaclass=BaseModelMeta):
+    model_config = {
+        'arbitrary_types_allowed': True,
+    }

--- a/restdantic/relations.py
+++ b/restdantic/relations.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from django.db.models import QuerySet
+from pydantic import Field
+
+
+def LookupRelatedField(  # noqa C901
+    *, lookup: str, queryset: QuerySet, **kwargs
+) -> Any:
+    return Field(lookup=lookup, queryset=queryset, is_related_lookup=True, **kwargs)

--- a/restdantic/validators.py
+++ b/restdantic/validators.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from pydantic_core.core_schema import ValidationInfo
+
+
+def validate_lookup_related_field(cls, value: Any, info: ValidationInfo):
+    json_schema_extra = cls.model_fields[info.field_name].json_schema_extra
+    queryset = json_schema_extra['queryset']
+    lookup_field = json_schema_extra['lookup']
+    many = "list" in str(cls.model_fields[info.field_name].annotation)
+
+    if many:
+        if not isinstance(value, list):
+            raise TypeError(f"Invalid type. Expected list, got {type(value).__name__}.")
+        if not all(isinstance(v, int) for v in value):
+            raise TypeError(f"Invalid type. Expected list of ints, got {type(value).__name__}.")
+        filter_kwargs = {f'{lookup_field}__in': value}
+    else:
+        if not isinstance(value, int):
+            raise TypeError(f"Invalid type. Expected int, got {type(value).__name__}.")
+        filter_kwargs = {lookup_field: value}
+
+    try:
+        objects = queryset.filter(**filter_kwargs)
+        if many:
+            if len(objects) != len(value):
+                object_values = set(getattr(obj, lookup_field) for obj in objects)
+                invalid_values = set(value) - object_values
+                raise ValueError(f"Invalid {lookup_field}(s) {invalid_values} - object(s) do not exist.")
+            return list(objects)
+        else:
+            return objects.get()
+    except queryset.model.DoesNotExist:
+        raise ValueError(f'Invalid {lookup_field} "{value}" - object does not exist.')
+    except TypeError:
+        raise TypeError(f"Invalid type. Expected int or list, got {type(value).__name__}.")

--- a/tests/django_test_app/api.py
+++ b/tests/django_test_app/api.py
@@ -1,12 +1,12 @@
 from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
 
-from tests.django_test_app.models import SampleModel
-from tests.django_test_app.serializers import SampleSerializer
+from tests.django_test_app.models import Book
+from tests.django_test_app.serializers import BookSerializer
 
 
-class SampleViewSet(mixins.ListModelMixin, GenericViewSet):
-    serializer_class = SampleSerializer
+class BookViewSet(mixins.ListModelMixin, GenericViewSet):
+    serializer_class = BookSerializer
 
     def get_queryset(self):
-        return SampleModel.objects.all()
+        return Book.objects.all()

--- a/tests/django_test_app/factories.py
+++ b/tests/django_test_app/factories.py
@@ -1,0 +1,38 @@
+import factory
+from .models import Author, Book, Review, Genre
+from factory.django import DjangoModelFactory
+
+
+class AuthorFactory(DjangoModelFactory):
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    date_of_birth = factory.Faker('date_of_birth')
+
+    class Meta:
+        model = Author
+
+
+class GenreFactory(DjangoModelFactory):
+    name = factory.Faker('word')
+
+    class Meta:
+        model = Genre
+
+
+class BookFactory(DjangoModelFactory):
+    title = factory.Faker('sentence')
+    author = factory.SubFactory(AuthorFactory)
+    publish_date = factory.Faker('date')
+
+    class Meta:
+        model = Book
+
+
+class ReviewFactory(DjangoModelFactory):
+    reviewer_name = factory.Faker('name')
+    book = factory.SubFactory(BookFactory)
+    review_text = factory.Faker('paragraph')
+    rating = factory.Faker('random_int', min=1, max=5)
+
+    class Meta:
+        model = Review

--- a/tests/django_test_app/models.py
+++ b/tests/django_test_app/models.py
@@ -1,5 +1,38 @@
 from django.db import models
 
 
-class SampleModel(models.Model):
-    pass
+class Author(models.Model):
+    first_name = models.CharField(max_length=100)
+    last_name = models.CharField(max_length=100)
+    date_of_birth = models.DateField()
+
+    def __str__(self):
+        return f'{self.first_name} {self.last_name}'
+
+
+class Genre(models.Model):
+    name = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.name
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=200)
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
+    publish_date = models.DateField()
+    genres = models.ManyToManyField(Genre)
+
+    def __str__(self):
+        return self.title
+
+
+class Review(models.Model):
+    reviewer_name = models.CharField(max_length=100)
+    book = models.ForeignKey(Book, on_delete=models.CASCADE)
+    review_text = models.TextField()
+    rating = models.IntegerField()
+
+    def __str__(self):
+        return f'{self.reviewer_name} ({self.rating})'
+

--- a/tests/django_test_app/serializers.py
+++ b/tests/django_test_app/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
 
 
-class SampleSerializer(serializers.Serializer):
+class BookSerializer(serializers.Serializer):
     id = serializers.IntegerField()

--- a/tests/django_test_app/urls.py
+++ b/tests/django_test_app/urls.py
@@ -1,9 +1,9 @@
 from rest_framework import routers
 
-from tests.django_test_app.api import SampleViewSet
+from tests.django_test_app.api import BookViewSet
 
 router = routers.SimpleRouter()
 
-router.register(r'samples', SampleViewSet, 'SampleViewSet')
+router.register(r'samples', BookViewSet, 'books')
 
 urlpatterns = router.urls

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,10 +1,10 @@
 import pytest
 from rest_framework.reverse import reverse
 
+pytestmark = pytest.mark.django_db
 
-@pytest.mark.django_db()
 def test_samples(client):
     url = reverse(
-        'SampleViewSet-list'
+        'books-list'
     )
     client.get(url).content

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,0 +1,83 @@
+import pytest
+from django.db import connection
+
+from pydantic_core import ValidationError
+
+from restdantic.models import BaseModel
+from restdantic.relations import LookupRelatedField
+from tests.django_test_app.factories import AuthorFactory, BookFactory, GenreFactory
+from tests.django_test_app.models import Author, Genre
+from django.test.utils import CaptureQueriesContext
+
+pytestmark = pytest.mark.django_db
+
+
+class BookSchema(BaseModel):
+    title: str
+    author: Author = LookupRelatedField(lookup='id', queryset=Author.objects.all())
+
+
+class BookWithGenresSchema(BaseModel):
+    title: str
+    genres: list[Genre] = LookupRelatedField(lookup='id', queryset=Genre.objects.all())
+
+
+def test_lookup_related_field_raises_error_if_object_does_not_exist():
+    with pytest.raises(ValidationError) as error:
+        BookSchema(title='test', author=2)
+
+    assert error.value.errors() == [
+        {
+            'ctx': {
+                'error': 'Invalid id "2" - object does not exist.'
+            },
+            'input': 2,
+            'loc': ('author',),
+            'msg': 'Value error, Invalid id "2" - object does not exist.',
+            'type': 'value_error',
+            'url': 'https://errors.pydantic.dev/0.30.0/v/value_error'
+        }
+    ]
+
+
+def test_lookup_related_field_returns_object_if_object_exists():
+    author = AuthorFactory()
+    book = BookFactory(author=author)
+    schema = BookSchema(title=book.title, author=book.author.id)
+    assert schema.author == author
+
+
+def test_lookup_related_field_for_raises_error_if_any_object_from_list_does_not_exist():
+    genre = GenreFactory()
+    with pytest.raises(ValidationError) as error:
+        BookWithGenresSchema(title='test', genres=[genre.id, 2, 3])
+
+    assert error.value.errors() == [
+        {
+            'ctx': {
+                'error': 'Invalid id(s) {2, 3} - object(s) do not exist.'
+            },
+            'input': [1, 2, 3],
+            'loc': ('genres',),
+            'msg': 'Value error, Invalid id(s) {2, 3} - object(s) do not exist.',
+            'type': 'value_error',
+            'url': 'https://errors.pydantic.dev/0.30.0/v/value_error'
+        }
+    ]
+
+
+def test_lookup_related_field_returns_list_of_objects_if_all_objects_exist():
+    genre1 = GenreFactory()
+    genre2 = GenreFactory()
+    book = BookFactory()
+    schema = BookWithGenresSchema(title=book.title, genres=[genre1.id, genre2.id])
+    assert schema.genres == [genre1, genre2]
+
+
+def test_lookup_related_field_makes_only_one_db_query_for_list():
+    genre1, genre2 = GenreFactory.create_batch(2)
+    book = BookFactory()
+    with CaptureQueriesContext(connection) as queries:
+        schema = BookWithGenresSchema(title=book.title, genres=[genre1.id, genre2.id])
+    assert schema.genres == [genre1, genre2]
+    assert len(queries) == 1


### PR DESCRIPTION
Add test models

Upgrade pydantic to v2

Note: 
 As agreed with @BezBartek for now we only support int lookups. We will figure out How to allow strings and type validation later

Note 2:
We should probably handle a scenario in which user defines field_validator for the LookupRelatedField